### PR TITLE
Allow the date-time separating string to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The local state
 | --- | --- |
 | dateFormat | <code>String</code> | 
 | timeFormat | <code>String</code> | 
+| dateTimeSeparator | <code>String</code> |
 | showDate | <code>Boolean</code> | 
 | showTime | <code>Boolean</code> | 
 | paddingX | <code>Number</code> | 

--- a/dtsel.js
+++ b/dtsel.js
@@ -36,6 +36,7 @@
      * @typedef {Object} Config
      * @property {String} dateFormat
      * @property {String} timeFormat
+     * @property {String} dateTimeSeparator
      * @property {Boolean} showDate
      * @property {Boolean} showTime
      * @property {Number} paddingX
@@ -61,7 +62,8 @@
             showTime: false,
             paddingX: 5,
             paddingY: 5,
-            direction: 'TOP'
+            direction: 'TOP',
+            dateTimeSeparator: ', '
         }
 
         if (!elem) {
@@ -77,6 +79,7 @@
         this.config = setDefaults(config, defaultConfig);
         this.dateFormat = this.config.dateFormat;
         this.timeFormat = this.config.timeFormat;
+        this.dateTimeSeparator = this.config.dateTimeSeparator;
         this.dateFormatRegEx = new RegExp("yyyy|yy|mm|dd", "gi");
         this.timeFormatRegEx = new RegExp("hh|mm|ss|a", "gi");
         this.inputElem = elem;
@@ -507,7 +510,7 @@
             var joined = new Date(date.getTime() + this.time);
             strings.push(renderTime(joined, this.settings));
         }
-        this.elem.value = strings.join(', ');
+        this.elem.value = strings.join(this.settings.dateTimeSeparator);
     }
 
     DTBox.prototype.onDateSelected = function (e) {


### PR DESCRIPTION
Can be added to config under key 'dateTimeSeparator'
Defaults to the previous fixed value.
Documentation amended to include new property.
Aim is to provide some some further control over the formatting while not requiring any changes for existing usages.